### PR TITLE
Fix select text overlap

### DIFF
--- a/src/components/Select.scss
+++ b/src/components/Select.scss
@@ -5,8 +5,13 @@
   // TODO correct inner padding, colors to match BS styles
 
   @import '~react-select/scss/default.scss';
-  
+
   .Select-input > input {
     height: 100%;
+  }
+
+  .Select-value {
+    // Allow space for the "x" and prevent text overlap
+    padding-right: 3rem !important;
   }
 }


### PR DESCRIPTION
This PR adds a CSS tweak to prevent `Select` option text from overlapping the small "x".  See the example screenshots below:

![screen shot 2017-01-23 at 9 54 01 am](https://cloud.githubusercontent.com/assets/37422/22216012/3760132a-e152-11e6-8ae5-530120da844f.png)
![screen shot 2017-01-23 at 9 53 49 am](https://cloud.githubusercontent.com/assets/37422/22216016/39ad67c2-e152-11e6-8f38-3df2348f7133.png)

